### PR TITLE
Fix Ruby warning for respond_to?

### DIFF
--- a/lib/nyc_geo_client.rb
+++ b/lib/nyc_geo_client.rb
@@ -20,7 +20,7 @@ module NYCGeoClient
   end
 
   # Delegate to NYCGeoClient::Client
-  def self.respond_to?(method)
+  def self.respond_to?(method, include_all=false)
     return client.respond_to?(method) || super
   end
 end


### PR DESCRIPTION
`lib/nyc_geo_client.rb` is producing warnings.

```
/home/david/.rvm/gems/ruby-2.3.0/gems/rspec-support-3.4.1/lib/rspec/support/recursive_const_methods.rb:67: warning: NYCGeoClient.respond_to?(:to_str) is old fashion which takes only one parameter
/home/david/.rvm/gems/ruby-2.3.0/gems/nyc_geo_client-0.1.0/lib/nyc_geo_client.rb:23: warning: respond_to? is defined here
```

Adding this additional parameter fixes the warning.
